### PR TITLE
Fix .cfg validation on Launch

### DIFF
--- a/app/assets/js/assetguard.js
+++ b/app/assets/js/assetguard.js
@@ -1495,9 +1495,16 @@ class AssetGuard extends EventEmitter {
         ? obPath.substring(0, obPath.toLowerCase().lastIndexOf(".pack.xz"))
         : obPath;
       if (!AssetGuard._validateLocal(validationPath, "MD5", artifact.hash)) {
-        asize += artifact.size * 1;
-        alist.push(artifact);
-        if (validationPath !== obPath) this.extractQueue.push(obPath);
+        // TODO: Fix Journeymap waypoints
+        if(!validationPath.endsWith(".cfg")){
+          asize += artifact.size * 1;
+          alist.push(artifact);
+          if (validationPath !== obPath) this.extractQueue.push(obPath);
+        }
+        else{
+          var filename = path.basename(validationPath);
+          console.log("Wanted to reinstall: %s", filename);
+        }
       }
       //Recursively process the submodules then combine the results.
       if (ob.getSubModules() != null) {


### PR DESCRIPTION
The new launcher is pretty nice with all the features it has but one thing bugs me the most:

Every time you launch the game. EVERY file gets checked on the hash value for potential corruption. 
Any chances to .cfg files will change the hash, so it replaces the file with a brand new one. Deleting any changes to it.

This is also why waypoints from Journeymap gets deleted, but I don't have time untill Friday to check that out.